### PR TITLE
NP-790: Fix bundled action runtime preset loading + add e2e smoke test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,16 +23,30 @@ jobs:
       # (slower) full Vitest suite runs.
       - run: npm run build
       # Guard against committed-bundle drift: GitHub's Actions runner
-      # executes the `lib/main.js` that is *checked in*, not whatever CI
+      # executes whatever is *checked in* under `lib/`, not whatever CI
       # rebuilds. Without this check a PR could change `src/` + rebuild
       # locally, commit only the `src/` change, and still pass CI while
-      # shipping a stale bundle to every consumer. `git diff --exit-code`
-      # fails the job if the freshly-built bundle diverges from the
-      # committed one, forcing the author to commit the rebuild.
-      - name: Ensure lib/main.js is up to date with src/
+      # shipping a stale bundle to every consumer.
+      #
+      # Two complementary checks:
+      #   1. `git diff --exit-code -- lib/` catches modifications to
+      #      tracked files (today: `lib/main.js`).
+      #   2. `git ls-files --others --exclude-standard -- lib/` catches
+      #      brand-new untracked files the bundler might start emitting
+      #      (e.g. sourcemaps, additional chunks) that a future `src/`
+      #      change could introduce without the author noticing.
+      - name: Ensure lib/ is up to date with src/
         run: |
+          git diff --stat -- lib/ || true
           if ! git diff --exit-code -- lib/; then
-            echo "::error::\`lib/main.js\` is stale. Run \`npm run build\` locally and commit the updated bundle."
+            echo "::error::Files under \`lib/\` are stale. Run \`npm run build\` locally and commit the updated bundle."
+            exit 1
+          fi
+          untracked=$(git ls-files --others --exclude-standard -- lib/)
+          if [ -n "$untracked" ]; then
+            echo "::error::The build produced new files under \`lib/\` that are not committed:"
+            printf '  %s\n' $untracked
+            echo "::error::Commit the new artefact(s) or add them to \`.gitignore\`."
             exit 1
           fi
       - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,17 @@ jobs:
       # surfaces missing-file / bundler-config regressions before the
       # (slower) full Vitest suite runs.
       - run: npm run build
+      # Guard against committed-bundle drift: GitHub's Actions runner
+      # executes the `lib/main.js` that is *checked in*, not whatever CI
+      # rebuilds. Without this check a PR could change `src/` + rebuild
+      # locally, commit only the `src/` change, and still pass CI while
+      # shipping a stale bundle to every consumer. `git diff --exit-code`
+      # fails the job if the freshly-built bundle diverges from the
+      # committed one, forcing the author to commit the rebuild.
+      - name: Ensure lib/main.js is up to date with src/
+        run: |
+          if ! git diff --exit-code -- lib/; then
+            echo "::error::\`lib/main.js\` is stale. Run \`npm run build\` locally and commit the updated bundle."
+            exit 1
+          fi
       - run: npm test

--- a/src/action.ts
+++ b/src/action.ts
@@ -216,6 +216,14 @@ export default async function main() {
   // `preset: 'conventionalcommits'` would trigger a dynamic
   // `import-from-esm` lookup that fails on the Actions runner
   // where no `node_modules` directory exists.
+  //
+  // Note: upstream `load-changelog-config.js` only reads
+  // `loadedConfig.commits` (never merging a plugin-supplied `commits`
+  // field), so when no `preset` / `config` is passed `commitOpts`
+  // always comes from the angular default preset. That is harmless
+  // today — angular and conventionalcommits both default to
+  // `{ ignore: undefined, merges: false }` — but is worth knowing if
+  // those defaults ever diverge upstream.
   const resolvedPreset = conventionalCommitsPreset({
     types: mergeWithDefaultChangelogRules(mappedReleaseRules),
   });

--- a/tests/bundle.smoke.test.ts
+++ b/tests/bundle.smoke.test.ts
@@ -54,7 +54,8 @@ interface ChildResult {
  * Drain stdout/stderr asynchronously while the child runs so large
  * bursts of startup output can't deadlock the parent. Always resolves
  * (never rejects) so the caller can assert on the captured streams even
- * if the child crashed, exited non-zero, or had to be SIGKILLed.
+ * if the child crashed, exited non-zero, had to be SIGKILLed, or failed
+ * to spawn in the first place.
  */
 function runChildAndCapture(
   child: ChildProcess,
@@ -63,21 +64,39 @@ function runChildAndCapture(
   return new Promise((resolve) => {
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];
+    let settled = false;
+
+    const finish = (overrides: Partial<ChildResult>): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({
+        stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+        stderr: Buffer.concat(stderrChunks).toString('utf8'),
+        status: null,
+        signal: null,
+        ...overrides,
+      });
+    };
+
     child.stdout?.on('data', (chunk: Buffer) => stdoutChunks.push(chunk));
     child.stderr?.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+
+    // If spawn itself fails (e.g. ENOENT for the node binary), Node emits
+    // `error` and never a `close`. Fold the error into stderr so the
+    // caller still sees a useful message instead of hanging until the
+    // SIGKILL timer fires.
+    child.on('error', (err) => {
+      stderrChunks.push(Buffer.from(`\n${String(err)}\n`));
+      finish({});
+    });
 
     const timer = setTimeout(() => {
       child.kill('SIGKILL');
     }, timeoutMs);
 
     child.on('close', (status, signal) => {
-      clearTimeout(timer);
-      resolve({
-        stdout: Buffer.concat(stdoutChunks).toString('utf8'),
-        stderr: Buffer.concat(stderrChunks).toString('utf8'),
-        status,
-        signal,
-      });
+      finish({ status, signal });
     });
   });
 }
@@ -209,8 +228,18 @@ describe('bundled action artefact', () => {
     };
 
     const server = createServer(handleRequest);
-    await new Promise<void>((resolve) => {
-      server.listen(0, '127.0.0.1', resolve);
+    await new Promise<void>((resolve, reject) => {
+      // Without an `error` listener, a failed `listen` (e.g. EADDRINUSE
+      // on a constrained CI host) would never reject and the test would
+      // silently hang until vitest's test timeout.
+      const onError = (err: Error): void => {
+        reject(err);
+      };
+      server.once('error', onError);
+      server.listen(0, '127.0.0.1', () => {
+        server.off('error', onError);
+        resolve();
+      });
     });
 
     try {


### PR DESCRIPTION
## Summary

Fixes a runtime crash consumers hit when using `StackAdapt/github-tag-action@v7`:

```
Error: TypeError [ERR_INVALID_ARG_TYPE]: The "paths[0]" argument must be of type string. Received undefined
    at resolve (node:path:1257:7)
    at resolveToFileURL (lib/main.js:41844:25)
    at importFrom (lib/main.js:41888:30)
    at load_changelog_config_default (lib/main.js:43164:99)
    at async generateNotes (lib/main.js:43239:50)
```

### Root cause

`@semantic-release/release-notes-generator/lib/load-changelog-config.js` resolves the `preset` option at runtime via `import-from-esm`. That helper walks the filesystem looking for `conventional-changelog-<preset>` in `node_modules` — a search that fundamentally cannot succeed in the bundled Action runtime because GitHub Actions does not run `npm install` on the action dir, and our esbuild bundle is a single self-contained file. The upstream silent-then-fallthrough code path ends up calling `path.resolve(undefined, ...)` when the context's `cwd` is unset, which is how the confusing `ERR_INVALID_ARG_TYPE` surfaces.

### Fix

- Statically import `conventional-changelog-conventionalcommits` in `src/action.ts` so esbuild inlines it.
- Call the preset factory ourselves and hand the resolved `parser` / `writer` options to `generateNotes` as `parserOpts` / `writerOpts`. With no `preset` / `config` supplied, `load-changelog-config.js` takes its safe `conventional-changelog-angular` fallback (also statically imported upstream and therefore bundled) and shallow-merges our options on top — conventionalcommits' keys win.
- Pass `cwd: process.cwd()` on the context as belt-and-suspenders.

### Integration test that would have caught this

`tests/bundle.smoke.test.ts` gains a third test case that runs the shipping bundle end-to-end:

- Spins up a local `node:http` mock server for `/repos/foo/bar/tags` and `/repos/foo/bar/compare/...`.
- Copies `lib/main.js` into `os.tmpdir()` (no sibling `node_modules` anywhere on the resolver walk).
- Spawns it with `GITHUB_API_URL` pointed at the mock and `INPUT_DRY_RUN=true` so it exits cleanly after changelog generation.
- Asserts no `ERR_INVALID_ARG_TYPE` / `paths\[0\]` / module-resolution errors, and positively asserts on `Dry run: not performing tag action.` to confirm execution walked past `generateNotes`.

Uses async `spawn` + Promise-based capture (not `spawnSync`) because the bundle emits enough startup stdio to deadlock `spawnSync` on macOS with captured pipes.

### Reviewer-hardening follow-up

- `runChildAndCapture` listens for child `error` so a failed spawn surfaces the error through captured stderr rather than hanging until the SIGKILL timer.
- Mock HTTP server's `listen` promise attaches a one-shot `error` handler so bind failures (EADDRINUSE on CI) reject cleanly instead of wedging the test until Vitest's timeout.
- Documented in `src/action.ts` that `commitOpts` always comes from angular when no `preset` / `config` is passed — harmless today (defaults match) but flagged for future upstream drift.

## Test plan

- [x] `npm run build` — bundle produces a 1.7 MB self-contained `lib/main.js`
- [x] `npm test` — 37 tests pass across 5 files
- [x] `npm run lint` — clean
- [x] `npm run check` — Prettier clean
- [x] `npm run typecheck` — clean
- [x] Against the previously-shipped (buggy) bundle the new smoke test reproduces the user-reported error line-for-line and fails; after the fix it passes
- [ ] Green CI on this PR
- [ ] After merge: move the floating `v7` tag to the merged commit so consumers pick up the fix

Made with [Cursor](https://cursor.com)